### PR TITLE
Wrap function args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,8 @@ Instead of writing "traditional" Pandas like this:
 .. code-block:: python
 
     df_in = pd.DataFrame({"x": range(5)})
-    df = df_in.assign(y = df_in.x // 2)
-    df = df.loc[df.y <= 1]
+    df = df_in.assign(y = df_in["x"] // 2)
+    df = df.loc[df["y"] <= 1]
     df
     #    x  y
     # 0  0  0
@@ -47,8 +47,8 @@ One can write:
 
     from pandas_selector import DF
     df = (df_in
-          .assign(y = DF.x // 2)
-          .loc[DF.y <= 1]
+          .assign(y = DF["x"] // 2)
+          .loc[DF["y"] <= 1]
          )
 
 This is especially handy when re-iterating on data frame manipulations
@@ -61,9 +61,9 @@ context:
 
     df = pd.DataFrame({
         "X": range(5),
-        "Y": ["1", "a", "c", "D", "e"],
+        "y": ["1", "a", "c", "D", "e"],
     })
-    df.loc[DF.y.str.isupper() | DF.y.str.isnumeric()]
+    df.loc[DF["y"]str.isupper() | DF["y"]str.isnumeric()]
     #    X  y
     # 0  0  1
     # 3  3  D
@@ -74,6 +74,34 @@ context:
     # 2  2
     # 3  3
     # 4  4
+
+You can even use ``DF`` in the arguments to methods:
+
+.. code-block:: python
+
+    df = pd.DataFrame({
+        "x": range(5),
+        "y": range(2, 7),
+    })
+    df.assign(z = DF['x'].clip(lower=2.2, upper=DF['y'].median()))
+    #    x  y    z
+    # 0  0  2  2.2
+    # 1  1  3  2.2
+    # 2  2  4  2.2
+    # 3  3  5  3.0
+    # 4  4  6  4.0
+
+When working with ``~pd.Series`` the ``S`` object exists. It can be used
+similar to ``DF``:
+
+.. code-block:: python
+
+  s = pd.Series(range(5))
+  s[s < 3]
+  # 0    0
+  # 1    1
+  # 2    2
+  # dtype: int64
 
 Similar projects for pandas
 ===========================

--- a/pandas_selector/df_accessor.py
+++ b/pandas_selector/df_accessor.py
@@ -128,12 +128,14 @@ class Method(WrapperBase):
         return f"<{type(self).__name__}: {self.name}({', '.join(arg_reprs)})>"
 
     def __str__(self):
-        # arg_reprs = (
-        #     [f"{a!r}" for a in self.args]
-        #     + [f"{k}={a!r}" for k, a in self.kwargs.items()]
-        #     )
-        arg_reprs = ("...",) if len(self.args) + len(self.kwargs) else ("",)
-        return f".{self.name}({', '.join(arg_reprs)})"
+        # Use shorter `str` representation for accessors and `repr` for the
+        # rest
+        fmt_arg = lambda a: str(a) if isinstance(a, AccessorBase) else repr(a)
+        arg_strs = (
+            [fmt_arg(a) for a in self.args]
+            + [f"{k}={fmt_arg(a)}" for k, a in self.kwargs.items()]
+            )
+        return f".{self.name}({', '.join(arg_strs)})"
 
     def _wrap_method_arg(self, arg, root_obj):
         if isinstance(arg, AccessorBase):

--- a/tests/test_method_arg_wrapping.py
+++ b/tests/test_method_arg_wrapping.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import pytest
+
+from pandas_selector import DF
+
+
+@pytest.fixture
+def df():
+    return pd.DataFrame({"x": range(5)})
+
+
+def test_method_arg_wrapping(df):
+    selector = DF["x"].clip(DF.loc[2, "x"])
+    test = selector(df).tolist()
+    assert test == [2, 2, 2, 3, 4]
+
+def test_method_2arg_wrapping(df):
+    selector = DF["x"].clip(DF.loc[2, "x"], DF.loc[3, "x"])
+    test = selector(df).tolist()
+    assert test == [2, 2, 2, 3, 3]
+
+def test_method_kwarg_wrapping(df):
+    selector = DF["x"].clip(lower=DF.loc[2, "x"])
+    test = selector(df).tolist()
+    assert test == [2, 2, 2, 3, 4]
+
+def test_method_2_kwarg_wrapping(df):
+    selector = DF["x"].clip(lower=DF.loc[2, "x"], upper=DF.loc[3, "x"])
+    test = selector(df).tolist()
+    assert test == [2, 2, 2, 3, 3]
+
+def test_method_mixed_arg_wrapping(df):
+    selector = DF["x"].clip(DF.loc[2, "x"], upper=DF.loc[3, "x"])
+    test = selector(df).tolist()
+    assert test == [2, 2, 2, 3, 3]

--- a/tests/test_str.py
+++ b/tests/test_str.py
@@ -1,6 +1,8 @@
+from pandas_selector.df_accessor import AccessorBase
 from pandas_selector import DF, S
 
 
+# DataFrame accessor formatting
 def test_attribute_str():
     assert ".a" == str(DF.a)
 
@@ -20,16 +22,26 @@ def test_item_attribute_str():
     assert "['a'].BB" == str(DF["a"].BB)
 
 def test_operator_str():
-    assert ".x.__lt__(...)" == str(DF.x < None)
+    assert ".x.__lt__(9)" == str(DF.x < 9)
 
 def test_column_method_no_args_str():
     assert ".x.abs()" == str(DF.x.abs())
 
-def test_column_method_with_args_str():
-    assert ".x.isin(...)" == str(DF.x.isin({None}))
+def test_column_method_with_arg_str():
+    assert ".x.isin({1, 2})" == str(DF.x.isin({1, 2}))
 
+def test_column_method_with_args_str():
+    assert ".x.clip(1, 2)" == str(DF.x.clip(1, 2))
+
+def test_column_method_with_arg_kwarg_str():
+    assert ".x.clip(1, upper=2)" == str(DF.x.clip(1, upper=2))
+
+def test_method_with_nested_args_str():
+    assert ".x.method_name(.y.min())" == str(DF.x.method_name(DF.y.min()))
+
+# Series accessor formatting
 def test_series_operator_str():
-    assert ".__lt__(...)" == str(S < None)
+    assert ".__lt__(8)" == str(S < 8)
 
 def test_series_attribute_str():
     assert ".index" == str(S.index)
@@ -37,5 +49,14 @@ def test_series_attribute_str():
 def test_series_method_no_args_str():
     assert ".abs()" == str(S.abs())
 
+def test_series_method_with_arg_str():
+    assert ".isin({3, 4})" == str(S.isin({3, 4}))
+
 def test_series_method_with_args_str():
-    assert ".isin(...)" == str(S.isin({None}))
+    assert ".meth_name(3, 'a')" == str(S.meth_name(3, 'a'))
+
+def test_series_method_with_kwarg_str():
+    assert ".clip(lower=1)" == str(S.clip(lower=1))
+
+def test_series_method_with_arg_kwarg_str():
+    assert ".clip(1, upper=2)" == str(S.clip(1, upper=2))


### PR DESCRIPTION
This PR adds full support for `DF` and `S` in function arguments. Previously, only the first argument was expanded if ti was a `DF`- or `S`-expression.